### PR TITLE
Fix deprecated usage of html5tokenizer in html-comments

### DIFF
--- a/html-comments/Cargo.toml
+++ b/html-comments/Cargo.toml
@@ -2,7 +2,7 @@
 name = "html-comments"
 version = "0.1.0"
 edition = "2021"
-authors = ["Mohamed Tarek @0xr00t3d"]
+authors = ["Mohamed Tarek @pwnxpl0it"]
 description = "Pulls out comments from html"
 repository = "https://github.com/knassar702/hacks"
 keywords = ["html-comments","htmlcomments","bugbounty"]
@@ -18,4 +18,4 @@ panic = "abort"
 strip = true
 
 [dependencies]
-html5tokenizer = "0.4.0"
+html5tokenizer = "=0.5.2"

--- a/html-comments/src/main.rs
+++ b/html-comments/src/main.rs
@@ -1,5 +1,5 @@
 use std::io;
-use html5tokenizer::{Tokenizer, Token};
+use html5tokenizer::{NaiveParser, Token};
 
 fn main() {
     let mut html = String::from("");
@@ -14,7 +14,7 @@ fn main() {
             }
         }
 
-    for token in Tokenizer::new(html.as_str()).infallible(){
+    for token in NaiveParser::new(html.as_str()).flatten(){
         match token{
             Token::Comment(comment) => {
                 println!("{}",comment.replace("\n"," ").trim());


### PR DESCRIPTION
Hi, This PR fixes a compilation error related to the usage of a deprecated code from a yanked version of html5tokenizer (0.4.0) [Versions](https://crates.io/crates/html5tokenizer/versions)

```
error: failed to compile `html-comments v0.1.0 (https://github.com/knassar702/hacks#a61a976a)`, intermediate artifacts can be found at `/tmp/cargo-installnpRfA6`

Caused by:
  failed to select a version for the requirement `html5tokenizer = "^0.4.0"`
  candidate versions found which didn't match: 0.5.2, 0.5.1, 0.5.0
  location searched: crates.io index
  required by package `html-comments v0.1.0 /home/user/.cargo/git/checkouts/hacks-5b2cd6b615994e27/a61a976/html-comments)`
```